### PR TITLE
Inherit project in successor/predecessor form

### DIFF
--- a/project_time_sequence/project_time_sequence_view.xml
+++ b/project_time_sequence/project_time_sequence_view.xml
@@ -31,9 +31,9 @@
 					<page groups="project.group_project_user"
                           string="Relationships">
                         <separator string="Predecessor Activities" colspan="4"/>
-                        <field colspan="4" height="150" name="predecessor_ids" nolabel="1" domain="[('project_id','=',project_id)]"/>
+                        <field colspan="4" height="150" name="predecessor_ids" nolabel="1" domain="[('project_id','=',project_id)]" context="{'default_project_id': project_id}"/>
                         <separator string="Successor Activities" colspan="4"/>
-                        <field colspan="4" height="150" name="successor_ids" nolabel="1" domain="[('project_id','=',project_id)]"/>                            
+                        <field colspan="4" height="150" name="successor_ids" nolabel="1" domain="[('project_id','=',project_id)]" context="{'default_project_id': project_id}"/>                            
                     </page>                    
         		</xpath>              	        		        		
             </field>


### PR DESCRIPTION
Creating predecessor or successor from the form view doesn't inherit the project from the originating task. This commit fixes it.