### PR TITLE
[10.0] [ADD] stock_location_analytic_procurement

### DIFF
--- a/stock_location_analytic_procurement/README.rst
+++ b/stock_location_analytic_procurement/README.rst
@@ -1,0 +1,29 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=============================
+Procurement Location Analytic
+=============================
+
+For sales, the source location should contain the same analytic account
+than the order. If it's a dropship two movements have to be done at the
+same time. This module checks the route for a sales order.
+
+
+Usage
+=====
+
+Select the analytic account in the SO. The picking type must be one with a
+good source location
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+

--- a/stock_location_analytic_procurement/__init__.py
+++ b/stock_location_analytic_procurement/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/stock_location_analytic_procurement/__manifest__.py
+++ b/stock_location_analytic_procurement/__manifest__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Procurement Location Analytic',
+    'version': '10.0.1.0.0',
+    'category': 'Logistics',
+    'summary': 'Control routes when using analytic locations',
+    'author': 'Eficent',
+    'website': 'http://www.eficent.com',
+    'depends': [
+        'stock_analytic_account_location'
+    ],
+    'installable': True,
+}

--- a/stock_location_analytic_procurement/models/__init__.py
+++ b/stock_location_analytic_procurement/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import procurement_order

--- a/stock_location_analytic_procurement/models/procurement_order.py
+++ b/stock_location_analytic_procurement/models/procurement_order.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, models, _
+
+
+class ProcurementOrder(models.Model):
+    _inherit = "procurement.order"
+
+    @api.model
+    def _search_suitable_rule(self, domain):
+        """
+        Removing the rules with wrong picking type
+        """
+        res = super(ProcurementOrder, self)._search_suitable_rule(domain)
+        res_filtered = res.filtered(
+            lambda rule: rule.picking_type_id.default_location_src_id.
+            analytic_account_id == self.analytic_account_id or
+            self.location_id.analytic_account_id == self.analytic_account_id)
+        if res and not res_filtered:
+            self.message_post(body=_('''Either the procurement location
+                does not belong to the analytic account or no destination
+                location for that analytic account found in the rule.'''))
+        return res_filtered


### PR DESCRIPTION
Procurement Location Analytic
=============================

For sales, the source location should contain the same analytic account than the order. If it's a dropship two movements have to be done at the same time. This module checks the route for a sales order.