### PR TITLE
[10.0] [ADD] account_analytic_moves_extend

### DIFF
--- a/account_analytic_moves_extend/README.rst
+++ b/account_analytic_moves_extend/README.rst
@@ -1,0 +1,20 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=============================
+Account Analytic Moves Extend
+=============================
+Limits the creation of analytic lines associated to invoices accepted only when the move
+is associated to an expense or revenue account.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Eficent <http://www.eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+

--- a/account_analytic_moves_extend/__init__.py
+++ b/account_analytic_moves_extend/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import model

--- a/account_analytic_moves_extend/__manifest__.py
+++ b/account_analytic_moves_extend/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Analytic moves only for expenses and revenues",
+    "version": "10.0.1.0.0",
+    "author": "Eficent",
+    "license": 'AGPL-3',
+    "website": "www.eficent.com",
+    "description": """Limits the creation of analytic lines associated to
+        invoices accepted only when the move is associated to an expense or
+        revenue account.
+    """,
+    "depends": [
+        "account",
+        "analytic"
+    ],
+    "installable": True,
+}

--- a/account_analytic_moves_extend/model/__init__.py
+++ b/account_analytic_moves_extend/model/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import account_move_line

--- a/account_analytic_moves_extend/model/account_move_line.py
+++ b/account_analytic_moves_extend/model/account_move_line.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    @api.multi
+    def create_analytic_lines(self):
+        acc_ana_line_obj = self.env['account.analytic.line']
+        for obj_line in self:
+            # Only create analytic line if the associated account is
+            # Expense or Income.
+            if obj_line.account_id.user_type_id.name and\
+                    obj_line.account_id.user_type_id.type in ('Income',
+                                                              'Expenses'):
+                if obj_line.analytic_account_id:
+                    if obj_line.analytic_line_ids:
+                        super(AccountMoveLine, self).create_analytic_lines()
+        return True


### PR DESCRIPTION
Account Analytic Moves Extend
=============================
Limits the creation of analytic lines associated to invoices accepted only when the move is associated to an expense or revenue account.