### PR TITLE
[10.0] [MIG] purchase_delivery

### DIFF
--- a/purchase_delivery/README.rst
+++ b/purchase_delivery/README.rst
@@ -1,0 +1,34 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License AGPL-3
+
+=======================
+Purchase Delivery Costs
+=======================
+Allows you to add delivery methods in purchase orders and picking.
+
+This module makes it possible to add delivery method to purchase orders and
+can compute a shipping line in the purchase order or in the invoice when
+created from an incoming shipment.
+
+The application makes use of the same concepts of carrier and delivery grid
+extending them as follows:
+    * Introduces origin countries, states and ZIP in the delivery grid.
+    * Uses the cost defined in the grid, instead of the sale price.
+    * Uses the vendor address to match with the existing grid based on the
+    origin information defined in the grid.
+    * Uses the destination address (customer address for direct shipments
+    and warehouse otherwise) to determine the grid, based on the destination
+    parameters defined in the grid.
+
+In case that the incoming shipment contains moves that have multiple
+destination addresses, computes the average freight cost.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Eficent <http://www.eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+

--- a/purchase_delivery/__init__.py
+++ b/purchase_delivery/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services S.L.
+#        <contact@eficent.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import model

--- a/purchase_delivery/__manifest__.py
+++ b/purchase_delivery/__manifest__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services S.L.
+#        <contact@eficent.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Purchase Delivery Costs",
+    "version": "10.0.1.0.0",
+    "category": "Purchase Management",
+    "description": """Allows you to add delivery methods in purchase orders
+        and picking.""",
+    "author": "Eficent",
+    "website": "www.eficent.com",
+    "license": "AGPL-3",
+    "depends": [
+        "delivery",
+        "purchase"
+    ],
+    "data": [
+        "view/delivery_view.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/purchase_delivery/model/__init__.py
+++ b/purchase_delivery/model/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services S.L.
+#        <contact@eficent.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import delivery
+from . import purchase
+from . import stock

--- a/purchase_delivery/model/delivery.py
+++ b/purchase_delivery/model/delivery.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services S.L.
+#        <contact@eficent.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models, _
+from odoo.tools.safe_eval import safe_eval
+from odoo.exceptions import UserError
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = "delivery.carrier"
+
+    @api.multi
+    def get_price(self):
+        if self._context.get('purchase_order_id', False):
+            self.price = 0.0
+
+    @api.multi
+    def name_get(self):
+        if not len(self.ids):
+            return []
+        if self._context is None:
+            self._context = {}
+        return [(r['id'], r['name']) for r in self.read(['name'])]
+
+    @api.multi
+    def grid_src_dest_get(self, src_id, dest_id):
+        dest = self.env['res.partner'].browse(dest_id)
+        src = self.env['res.partner'].browse(src_id)
+        for carrier in self:
+            get_id = lambda x: x.id
+            country_ids = map(get_id, carrier.country_ids)
+            state_ids = map(get_id, carrier.state_ids)
+            src_country_ids = map(get_id, carrier.src_country_ids)
+            src_state_ids = map(get_id, carrier.src_state_ids)
+            if country_ids and dest.country_id.id not in country_ids:
+                continue
+            if state_ids and dest.state_id.id not in state_ids:
+                continue
+            if carrier.zip_from and (dest.zip or '') < carrier.zip_from:
+                continue
+            if carrier.zip_to and (dest.zip or '') > carrier.zip_to:
+                continue
+            if src_country_ids and src.country_id.id not in \
+                    src_country_ids:
+                continue
+            if src_state_ids and src.state_id.id not in src_state_ids:
+                continue
+            if carrier.src_zip_from and (src.zip or '') < carrier.src_zip_from:
+                continue
+            if carrier.src_zip_to and (src.zip or '') > carrier.src_zip_to:
+                continue
+        return carrier
+
+    src_country_ids = fields.Many2many(
+        'res.country',
+        'delivery_grid_src_country_rel',
+        'grid_id',
+        'country_id',
+        'Source Countries'
+    )
+    src_state_ids = fields.Many2many(
+        'res.country.state',
+        'delivery_grid_src_state_rel',
+        'grid_id',
+        'state_id',
+        'Source States'
+    )
+    src_zip_from = fields.Char(
+        'Start Source Zip',
+        size=12
+    )
+    src_zip_to = fields.Char(
+        'To Source Zip',
+        size=12
+    )
+
+    @api.multi
+    def get_price_available(self, order):
+        self.ensure_one()
+        total = weight = volume = quantity = 0
+        total_delivery = 0.0
+        for line in order.order_line:
+            if not line.product_id:
+                continue
+            qty = line.product_uom._compute_quantity(line.product_qty,
+                                                     line.product_id.uom_id)
+            weight += (line.product_id.weight or 0.0) * qty
+            volume += (line.product_id.volume or 0.0) * qty
+            quantity += qty
+        total = (order.amount_total or 0.0) - total_delivery
+        total = order.currency_id.with_context(date=order.date_order).\
+            compute(total, order.company_id.currency_id)
+
+        return self.get_price_from_picking(total, weight, volume, quantity)
+
+    def get_price_from_picking(self, total, weight, volume, quantity):
+        price = 0.0
+        criteria_found = False
+        price_dict = {
+            'price': total,
+            'volume': volume,
+            'weight': weight,
+            'wv': volume * weight,
+            'quantity': quantity
+        }
+        for line in self.price_rule_ids:
+            test = safe_eval(line.variable + line.operator + str(line.max_value
+                                                                 ), price_dict)
+            if test:
+                price = line.list_base_price + line.list_price * price_dict[
+                    line.variable_factor]
+                criteria_found = True
+                break
+        if not criteria_found:
+            raise UserError(_("""Selected product in the delivery method
+                doesn't fulfill any of the delivery carrier(s) criteria."""))
+        return price

--- a/purchase_delivery/model/purchase.py
+++ b/purchase_delivery/model/purchase.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services S.L.
+#        <contact@eficent.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    carrier_id = fields.Many2one(
+        "delivery.carrier",
+        "Delivery Method",
+        help="""Complete this field if you plan to invoice the shipping based
+            on picking."""
+    )
+
+    @api.onchange('partner_id', 'company_id')
+    def onchange_partner_id(self):
+        self.carrier_id = self.partner_id.property_delivery_carrier_id.id
+
+    @api.model
+    def _prepare_picking(self):
+        result = super(PurchaseOrder, self)._prepare_picking()
+        result.update({
+            'carrier_id': self.carrier_id.id
+        })
+        return result
+
+    @api.multi
+    def delivery_set(self):
+        for order in self:
+            carrier = order.carrier_id
+            src_address_id = order.partner_id
+            dest_address_id = order.dest_address_id or False
+            if (not dest_address_id and order.picking_type_id.warehouse_id and
+                    order.picking_type_id.warehouse_id.partner_id):
+                dest_address_id = order.picking_type_id.warehouse_id.partner_id
+            if not dest_address_id:
+                raise ValidationError(_('''
+                    No destination address available! An address must be added
+                    to the purchase order or the warehouse.'''))
+            grid_id = carrier.grid_src_dest_get(src_address_id.id,
+                                                dest_address_id.id)
+            if not grid_id:
+                raise ValidationError(_('''No Grid Available! No grid matching
+                    for this carrier!.'''))
+
+            if order.state not in ('draft', 'sent'):
+                raise ValidationError(_('''
+                    Order not in Draft State! The order state have to be
+                    draft to add delivery lines.'''))
+            price_unit = grid_id.get_price_available(order)
+            self._create_delivery_line(order, grid_id, price_unit)
+        return True
+
+    def _create_delivery_line(self, order, grid_id, price_unit):
+        PurchaseOrderLine = self.env['purchase.order.line']
+
+        taxes = grid_id.product_id.taxes_id.\
+            filtered(lambda t: t.company_id.id == grid_id.company_id.id)
+        taxes_ids = taxes.ids
+        if self.partner_id and self.fiscal_position_id:
+            taxes_ids = self.fiscal_position_id.\
+                map_tax(taxes, grid_id.product_id, self.partner_id).ids
+        # create the purchase order line
+        values = {
+            'order_id': order.id,
+            'name': grid_id.name,
+            'product_qty': 1,
+            'product_uom': grid_id.product_id.uom_id.id,
+            'product_id': grid_id.product_id.id,
+            'price_unit': price_unit,
+            'taxes_id': [(6, 0, taxes_ids)],
+            'date_planned': order.date_order,
+        }
+        if self.order_line:
+            values['sequence'] = self.order_line[-1].sequence + 1
+        pol = PurchaseOrderLine.sudo().create(values)
+        return pol
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    @api.multi
+    def _prepare_stock_moves(self, picking):
+        res = super(PurchaseOrderLine, self)._prepare_stock_moves(picking)
+        if self.order_id.picking_type_id.warehouse_id and not\
+                self.order_id.dest_address_id:
+            if not self.order_id.picking_type_id.warehouse_id.partner_id:
+                raise ValidationError(_('''Error! The warehouse must have an
+                address.'''))
+        if res:
+            res[0]['partner_id'] = self.order_id.picking_type_id.warehouse_id.\
+                partner_id.id or False
+        return res

--- a/purchase_delivery/model/stock.py
+++ b/purchase_delivery/model/stock.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-17 Eficent Business and IT Consulting Services S.L.
+#        <contact@eficent.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.multi
+    def do_transfer(self):
+        self.ensure_one()
+        res = super(StockPicking, self).do_transfer()
+        self._add_delivery_cost_to_po()
+        return res
+
+    @api.multi
+    def _add_delivery_cost_to_po(self):
+        self.ensure_one()
+        purchase_order = self.purchase_id
+        if purchase_order:
+            price_unit = self.carrier_id.get_price_available(purchase_order)
+            purchase_order._create_delivery_line(self.purchase_id,
+                                                 self.carrier_id, price_unit)

--- a/purchase_delivery/view/delivery_view.xml
+++ b/purchase_delivery/view/delivery_view.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_delivery_carrier_form" model="ir.ui.view">
+        <field name="name">delivery.carrier.form</field>
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='destination']"  position="after">
+                <page string="Origin">
+                    <group>
+                        <group>
+                            <field name="src_country_ids" widget="many2many_tags"/>
+                            <field name="src_state_ids" widget="many2many_tags"/>
+                        </group>
+                        <group>
+                            <label for="src_zip_from" string="Zip"/>
+                            <div>
+                                <field name="src_zip_from" class="oe_inline"/>
+                                -
+                                <field name="src_zip_to" class="oe_inline"/>
+                            </div>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_order_withcarrier_form" model="ir.ui.view">
+        <field name="name">delivery.purchase.order_withcarrier.form.view</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='origin']" position="after">
+                <group style="width: 65%%">
+                    <label for="carrier_id"/>
+                    <div>
+                        <field name="carrier_id" context="{'purchase_order_id':active_id or False}" class="oe_inline"/>
+                        <button name="delivery_set" string="Add in Quote" type="object"
+                            class="oe_edit_only"
+                            attrs="{'invisible':['|',('carrier_id','=',False),('state','not in',('draft','sent'))]}"/>
+                        <br/>
+                        <label string="If you don't 'Add in Quote', the exact price will be computed when invoicing based on incoming shipment(s)."
+                            class="oe_edit_only"
+                            attrs="{'invisible':['|',('carrier_id','=',False),('state','not in',('draft','sent'))]}"/>
+                    </div>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+
+</odoo>


### PR DESCRIPTION
Purchase Delivery Costs
=======================
Allows you to add delivery methods in purchase orders and picking.

This module makes it possible to add delivery method to purchase orders and
can compute a shipping line in the purchase order or in the invoice when
created from an incoming shipment.

The application makes use of the same concepts of carrier and delivery grid
extending them as follows:
    * Introduces origin countries, states and ZIP in the delivery grid.
    * Uses the cost defined in the grid, instead of the sale price.
    * Uses the vendor address to match with the existing grid based on the
    origin information defined in the grid.
    * Uses the destination address (customer address for direct shipments
    and warehouse otherwise) to determine the grid, based on the destination
    parameters defined in the grid.

In case that the incoming shipment contains moves that have multiple
destination addresses, computes the average freight cost.