### PR TITLE
[12.0][IMP]timesheet valdiators, include superuser in validators

### DIFF
--- a/hr_timesheet_sheet_validators/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_sheet_validators/models/hr_timesheet_sheet.py
@@ -36,13 +36,14 @@ class HrTimesheetSheet(models.Model):
     @api.multi
     def _check_authorised_validator(self):
         for timesheet in self:
-            if self.env.uid not in timesheet.validator_user_ids.ids:
-                raise UserError(
-                    _(
-                        "You are not authorised to approve  or "
-                        "refuse this Timesheet."
+            if not self.env.user._is_superuser():
+                if self.env.uid not in timesheet.validator_user_ids.ids:
+                    raise UserError(
+                        _(
+                            "You are not authorised to approve  or "
+                            "refuse this Timesheet."
+                        )
                     )
-                )
 
     @api.multi
     def action_timesheet_draft(self):

--- a/hr_timesheet_sheet_validators/tests/test_hr_timesheet_sheet_validators.py
+++ b/hr_timesheet_sheet_validators/tests/test_hr_timesheet_sheet_validators.py
@@ -78,7 +78,9 @@ class TestComputeWorkdays(TransactionCase):
             self.timesheet_sheet.employee_id.parent_id.user_id
         ).action_timesheet_done()
         with self.assertRaises(UserError):
-            self.timesheet_sheet.action_timesheet_draft()
+            self.timesheet_sheet.sudo(
+                self.timesheet_sheet.employee_id.user_id
+            ).action_timesheet_draft()
         self.timesheet_sheet.sudo(
             self.timesheet_sheet.employee_id.parent_id.user_id
         ).action_timesheet_draft()


### PR DESCRIPTION
When automated actions take place in timesheets, we make sure the superuser is able to introduce changes.