### PR TITLE
[12.0][FIX] Correct gross_profit_plan calculation

### DIFF
--- a/analytic_plan_cost_revenue/models/analytic.py
+++ b/analytic_plan_cost_revenue/models/analytic.py
@@ -102,7 +102,7 @@ class AnalyticAccount(models.Model):
     def compute_gross_profit_plan(self):
         for account in self:
             account.gross_profit_plan = (
-                account.revenue_plan + account.total_cost_plan
+                account.revenue_plan - account.total_cost_plan
             )
 
     labor_cost_plan = fields.Float(


### PR DESCRIPTION
Applying https://github.com/ForgeFlow/eficent-odoo-addons/pull/210 again, that was revert wrongly.