### PR TITLE
[10.0][IMP] purchase_stock_analytic: change the location in the lines

### DIFF
--- a/purchase_stock_analytic/__manifest__.py
+++ b/purchase_stock_analytic/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Purchase Stock Analytic",
-    "version": "10.0.1.0.0",
+    "version": "10.0.2.0.0",
     "author": "Eficent, Odoo Community Association (OCA),"
               "Project Expert Team",
     "website": "http://project.expert",
@@ -18,6 +18,7 @@
         "stock_analytic_account",
         "purchase_analytic",
         "purchase_location_by_line",
+        "account_analytic_parent"
     ],
     'data': [
         'views/purchase_views.xml',

--- a/purchase_stock_analytic/models/purchase.py
+++ b/purchase_stock_analytic/models/purchase.py
@@ -79,6 +79,14 @@ class PurchaseOrderLine(models.Model):
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
+    @api.onchange('project_id')
+    def onchange_analytic(self):
+        for line in self.order_line:
+            if self.project_id:
+                line.location_dest_id = self.project_id.location_id
+            else:
+                line.location_dest_id = False
+
     @api.multi
     def button_confirm(self):
         for po in self:

--- a/purchase_stock_analytic/tests/test_purchase_order_line.py
+++ b/purchase_stock_analytic/tests/test_purchase_order_line.py
@@ -62,7 +62,7 @@ class TestPurchaseOrderLine(common.TransactionCase):
                 })],
         }
 
-    def test_check_purchase_analytic(self):
+    def test_01_check_purchase_analytic(self):
         self.po = self.PurchaseOrder.create(self.po_vals)
         self.po.button_confirm()
         self.picking = self.po.picking_ids
@@ -72,6 +72,19 @@ class TestPurchaseOrderLine(common.TransactionCase):
             self.picking.location_dest_id.analytic_account_id,
             self.po.project_id)
 
-    def test_check_purchaseno_analytic(self):
+    def test_02_check_purchaseno_analytic(self):
         with self.assertRaises(ValidationError):
             self.po = self.PurchaseOrder.create(self.po_no_anal_vals)
+
+    def test_03_check_purchase_analytic(self):
+        """
+        Test that if changed the analytic at parent level all the lines
+        get the location of the project
+        """
+        po = self.PurchaseOrder.new(self.po_no_anal_vals)
+        po.project_id = self.analytic_account
+        po._onchange_project_id()  # in purchase_analytic_module
+        po.onchange_analytic()  # in this module
+        self.assertEqual(
+            po.order_line.location_dest_id.analytic_account_id,
+            po.project_id)


### PR DESCRIPTION
when the analytic account is changed at PO level

related to 0000195

The dependency to account_analytic_parent was already there, but it was not being tested.